### PR TITLE
Changing regex to be less overzealous

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ async def on_message(message):
 
     #Yes, this is a regular expression. Yes, it's hard to read (It's a regex, of course it is). If you want a good explanation of what on earth is going on, I suggest you go to https://regex101.com/ and punch it in.
     #\u00FA is a letter u with an acute (that little mark above it)
-    if re.search('(no|none|not|nee)\s{0,10}(u|you|thee|t[u\u00FA])', message.content, re.M|re.I|re.U):
+    if re.search('(no|none|not|nee)\s{1,10}(u|you|thee|t[u\u00FA])', message.content, re.M|re.I|re.U):
         await message.channel.send('no u')
 
 client.run(config['config']['token'])

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ async def on_message(message):
 
     #Yes, this is a regular expression. Yes, it's hard to read (It's a regex, of course it is). If you want a good explanation of what on earth is going on, I suggest you go to https://regex101.com/ and punch it in.
     #\u00FA is a letter u with an acute (that little mark above it)
-    if re.search(r"(no|none|not|nee).*\n*(u|you|thee|t[u\u00FA])", message.content, re.M|re.I|re.U):
+    if re.search('(no|none|not|nee)\s{0,10}(u|you|thee|t[u\u00FA])', message.content, re.M|re.I|re.U):
         await message.channel.send('no u')
 
 client.run(config['config']['token'])


### PR DESCRIPTION
Regex now searches for "no" (or any of its alternatives) and "u" (or any of its alternatives) with 1 to 10 tolerated whitespace characters in between.

https://docs.python.org/3/library/re.html

\s -> "Matches Unicode whitespace characters (which includes [ \t\n\r\f\v], and also many other characters"